### PR TITLE
Add Terms of Service page and navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <div class="container">
             <nav>
                 <a href="privacy.html">Privacy Policy</a>
+                <a href="terms.html">Terms of Service</a>
             </nav>
             <div class="header-content">
                 <h1 class="game-title">Tee Time VR</h1>

--- a/privacy.html
+++ b/privacy.html
@@ -19,8 +19,14 @@
             <div class="privacy-content">
                 <p><strong>Effective Date:</strong> September 23, 2025</p>
 
+                <p><strong>Owner &amp; Data Controller</strong><br>
+                Fiskar Varmations (Avi Varma, doing business as &ldquo;Fiskar Varmations&rdquo;)<br>
+                Calgary, AB, Canada<br>
+                Contact: <a href="mailto:privacy@avivarma.ca">privacy@avivarma.ca</a><br>
+                This policy covers: Tee-Time VR for Meta Quest.</p>
+
                 <h3>Introduction</h3>
-                <p>"Tee Time VR" is developed and published by Avi Varma ("we," "us," or "our"). This Privacy Policy explains what
+                <p>"Tee Time VR" is developed and published by Avi Varma, a solo developer doing business as Fiskar Varmations ("we," "us," or "our"). This Privacy Policy explains what
                 information we process when you play Tee Time VR, why we process it, and the choices you have regarding that
                 information. Meta may ask you to review this policy before granting access to certain platform features, such as
                 multiplayer services.</p>
@@ -36,7 +42,7 @@
                     <li><strong>Gameplay and progression data.</strong> We store your local player preferences, achievements, and leaderboard scores so the game can save your progress, present rankings, and
                     prevent cheating. When you participate in multiplayer matches, your shot data and voice-chat participation are
                     transmitted in real time to the other players in the session.</li>
-                    <li><strong>Support information.</strong> If you contact us at <a href="mailto:HarshvardhanV98@gmail.com">HarshvardhanV98@gmail.com</a>
+                    <li><strong>Support information.</strong> If you contact us at <a href="mailto:privacy@avivarma.ca">privacy@avivarma.ca</a>
                     we will process the email address, message contents, and any attachments you choose to send so that we can
                     respond to your request.</li>
                 </ul>
@@ -88,7 +94,7 @@
 
                 <h3>Contact Us</h3>
                 <p>If you have any questions about this Privacy Policy or wish to exercise your privacy rights, please contact Avi
-                Varma at <a href="mailto:HarshvardhanV98@gmail.com">HarshvardhanV98@gmail.com</a>.</p>
+                Varma at <a href="mailto:privacy@avivarma.ca">privacy@avivarma.ca</a>.</p>
             </div>
         </div>
     </section>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service - Tee Time VR</title>
+    <link rel="stylesheet" href="style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body>
+    <header style="background: #2c3e50;">
+        <div class="container">
+            <h1 style="font-family: 'Poppins', sans-serif; font-weight: 600;">Terms of Service</h1>
+        </div>
+    </header>
+
+    <section id="terms-section">
+        <div class="container">
+            <div class="privacy-content">
+                <p><strong>Effective Date:</strong> September 23, 2025</p>
+
+                <p>These Terms of Service ("Terms") govern your access to and use of Tee Time VR, a free multiplayer virtual reality game developed by Avi Varma doing business as Fiskar Varmations ("Fiskar Varmations," "we," or "us"). By downloading, installing, or playing Tee Time VR, you agree to be bound by these Terms. If you do not agree, do not use the Service.</p>
+
+                <h3>Eligibility</h3>
+                <p>You must be at least 13 years old and meet any additional age or regional requirements imposed by the Meta platform to play Tee Time VR. By using the Service, you represent that you have the legal capacity to enter into these Terms.</p>
+
+                <h3>Accounts and Access</h3>
+                <p>Tee Time VR relies on your Meta account for authentication and multiplayer functionality. You are responsible for maintaining the security of your Meta account and for all activity that occurs in the game through your account. If you believe your account has been compromised, notify Meta and contact us immediately.</p>
+
+                <h3>Gameplay and Conduct</h3>
+                <p>The Service is designed for friendly, social play. You agree not to engage in behavior that is disruptive, harassing, defamatory, or otherwise harmful to other players. You also agree not to cheat, exploit bugs, or use unauthorized software that alters gameplay. We may take action, including removing you from a session or restricting access, if we determine that your conduct violates these Terms.</p>
+
+                <h3>Virtual Items and Purchases</h3>
+                <p>Tee Time VR is currently free to play and does not offer in-game purchases or premium content. If this changes, we will update these Terms and provide clear notice before you are asked to pay for any content or features.</p>
+
+                <h3>User Content</h3>
+                <p>When you use voice chat, text chat, or other interactive features, you may share content with other players. You grant Fiskar Varmations a limited license to use, store, and transmit that content as necessary to provide the Service. You are responsible for the content you share and must ensure that it complies with these Terms and applicable laws.</p>
+
+                <h3>Updates and Availability</h3>
+                <p>We may update Tee Time VR to fix bugs, improve performance, or add new features. Updates may be required for continued use of the Service. We do not guarantee that the Service will be available at all times or that it will be free from interruptions or errors.</p>
+
+                <h3>Termination</h3>
+                <p>You may stop using Tee Time VR at any time. We reserve the right to suspend or terminate access to the Service for any reason, including if we believe you have violated these Terms or the Meta platform policies.</p>
+
+                <h3>Disclaimers</h3>
+                <p>Tee Time VR is provided on an "as is" and "as available" basis without warranties of any kind, whether express or implied. To the fullest extent permitted by law, we disclaim all warranties, including implied warranties of merchantability, fitness for a particular purpose, and non-infringement. Your use of the Service is at your own risk.</p>
+
+                <h3>Limitation of Liability</h3>
+                <p>To the maximum extent permitted by law, Fiskar Varmations and its developer will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss of profits or data arising out of or in connection with your use of Tee Time VR. Our total liability for any claim arising from these Terms or the Service will not exceed CAD $50.</p>
+
+                <h3>Governing Law</h3>
+                <p>These Terms are governed by the laws of the Province of Alberta and the federal laws of Canada applicable therein, without regard to conflict of law principles. You agree that any disputes will be resolved in the courts located in Calgary, Alberta, unless applicable law requires otherwise.</p>
+
+                <h3>Changes to These Terms</h3>
+                <p>We may update these Terms from time to time. When we make material changes, we will post the updated Terms at this location and revise the effective date above. Continued use of Tee Time VR after the updated Terms take effect constitutes your acceptance of the changes.</p>
+
+                <h3>Contact</h3>
+                <p>If you have any questions about these Terms, please contact Avi Varma at <a href="mailto:privacy@avivarma.ca">privacy@avivarma.ca</a>.</p>
+            </div>
+        </div>
+    </section>
+
+    <footer>
+        <div class="container">
+            <p>&copy; 2025 Tee Time VR. All rights reserved.</p>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated Terms of Service page outlining usage, conduct, and liability for Tee Time VR
- link to the new Terms of Service from the main navigation alongside the privacy policy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d699e5696083268233427e85880525